### PR TITLE
✨ add quit cli command to service

### DIFF
--- a/WinthainerService/Program.cs
+++ b/WinthainerService/Program.cs
@@ -10,9 +10,17 @@ namespace WinthainerService
         [STAThread]
         static void Main(string[] args)
         {
-            new ProcessUtility().StartWinthainerServiceProcess();
-            new TrayIcon().ShowTrayIcon();
-            Application.Run();
+            if (args.Length == 1 &&  args[0] == "quit")
+            {
+                new ProcessUtility().EndWinthainerServiceProcess();
+                Application.Exit();
+            }
+            else
+            {
+                new ProcessUtility().StartWinthainerServiceProcess();
+                new TrayIcon().ShowTrayIcon();
+                Application.Run();
+            }
         }
     }
 }


### PR DESCRIPTION
If the tray icon crashes, there is now a possibility to cleanly quit the service.